### PR TITLE
Check if database is full

### DIFF
--- a/CIS22B_FinalProject/CIS22B_FinalProject/BookDatabase.cpp
+++ b/CIS22B_FinalProject/CIS22B_FinalProject/BookDatabase.cpp
@@ -123,19 +123,11 @@ void BookDatabase::addBook(Book book)
 {
 	try
 	{
-		if (size >= 1024)
-		{
-			char except[128] = "Unable to add book to database because the database is full.\n\0";
-			throw except;
-		}
-		else
-		{
-			books[size].setAll(book.getTitle(), book.getAuthor(), book.getIsbn(), book.getPublisher(),
-				book.getWholesaleCost(), book.getRetailPrice(), book.getDateAdded(), identifierCount);
-			identifierCount++;
-			size++;
-			writeFile();
-		}
+		books[size].setAll(book.getTitle(), book.getAuthor(), book.getIsbn(), book.getPublisher(),
+			book.getWholesaleCost(), book.getRetailPrice(), book.getDateAdded(), identifierCount);
+		identifierCount++;
+		size++;
+		writeFile();
 	}
 	catch (char e[])
 	{
@@ -353,6 +345,14 @@ void BookDatabase::addBookMenu()
 				else if (numBooksToAdd < 0)
 				{
 					cout << "That is an invalid number of books.\n";
+				}
+				else if (numBooksToAdd > 1024 - (identifierCount - 1))
+				{
+					done = true;
+					cout << "\nDatabase will be full! Database can have a maximum of 1024 books.\n";
+					cout << "\nPress return to continue.";
+					cin.ignore(1000, '\n');
+					cin.get();
 				}
 				else
 				{

--- a/CIS22B_FinalProject/CIS22B_FinalProject/Report.h
+++ b/CIS22B_FinalProject/CIS22B_FinalProject/Report.h
@@ -3,7 +3,7 @@
 
 #include "BookDatabase.h"
 
-class Report : public Book, BookDatabase
+class Report : public Book
 {
 private:
 	BookDatabase* database;


### PR DESCRIPTION
Change location of checking for a full database to prevent recursion.
This is different from how it was before. The previous version would
output an error message after all the books up to size 1024 were created.
This version checks before any books are created to see if database is
full, or will be full from the amount of books the user is trying to add. It still functions the same for the user.
